### PR TITLE
Extended temperature validation in power case.

### DIFF
--- a/api/validations/decorators.py
+++ b/api/validations/decorators.py
@@ -64,6 +64,8 @@ def power_to_flow(func):
         if 'power' in req:
             power = unit_convertion(req['power'], req['power_unit'], 'W', 'power')
             temperature_delta = abs(req['temperature_supply'] - req['temperature_return'])
+            if not temperature_delta:
+                return error_response(400, 'Temperature supply and return can not have the same value.')
             flow = power / (temperature_delta * req['density'] * req['specific_heat'])
             req.update({'flow': flow, 'flow_unit': 'm3/s'})
         return func(*args, req=req, **kwargs)

--- a/unittests/test_endpoints.py
+++ b/unittests/test_endpoints.py
@@ -154,6 +154,17 @@ def test_headloss_endpoint(app_fixture, req_json, expected_resp):
             'flow_unit': 'm3/h',
             'length': 1,
         },
+        {
+            'fluid': 'water',
+            'temperature_supply': 70,
+            'temperature_return': 70,
+            'nominal_diameter': 50,
+            'material': 'steel',
+            'power': 81,
+            'power_unit': 'kW',
+            'length': 10,
+            'headloss_unit': 'kPa',
+        },
     ),
 )
 def test_headloss_endpoint_failed(app_fixture, req_json):


### PR DESCRIPTION
Temperature return equals to temperature supply causes zero division error
and response 500 - fixed.